### PR TITLE
Center-crop the first frame like the last frame

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1230,7 +1230,7 @@ def _empty_image_conditioning(bundle, prompt, width, height, length, first_frame
     images = []
     keyframes = []
     if first_frame is not None:
-        image = h3._resize(first_frame[:1], width, height, "disabled")
+        image = h3._resize(first_frame[:1], width, height, "center")
         images.append(image)
         keyframes.append({"resolved_frame_index": 0, "image": image})
     if last_frame is not None:


### PR DESCRIPTION
## Problem

In `_empty_image_conditioning`, the first and last keyframes are resized with different crop modes:

```python
image = h3._resize(first_frame[:1], width, height, "disabled")  # stretches
...
image = h3._resize(last_frame[:1], width, height, "center")      # preserves aspect
```

`_resize` forwards that argument to `comfy.utils.common_upscale`, where `"disabled"` performs a non-uniform scale. Whenever the source image's aspect differs from the canvas, the first frame is squashed rather than cropped.

Concretely: an I2V run from a 1600x900 (16:9) image on the workflow's default `9:16` canvas produced a 480x864 video containing a horizontally compressed scene. Forcing 16:9 playback recovered correct proportions, confirming an anamorphic squash rather than a framing choice. The last frame, on the same run, is handled correctly.

## Change

Pass `"center"` for the first frame, matching the last frame.

Output dimensions are unchanged (`common_upscale` returns the requested `width x height` either way), so nothing downstream sees a different shape — the source is now cropped to the target aspect before scaling instead of being distorted into it.

## Note

Three sibling call sites still pass `"disabled"` — the reference-image paths around lines 1285 and 1304, and the frames path at 1317. They have the same behavior, but I left them alone since I only exercised the I2V keyframe path and the intent may differ for references. Happy to extend this if you'd like them consistent too.