### PR TITLE
Fix inconsistent title spelling in handdrawn_live guide.md

### DIFF
--- a/prompt_guides/handdrawn_live/guide.md
+++ b/prompt_guides/handdrawn_live/guide.md
@@ -5,7 +5,7 @@ description: |
 trigger-words: [手绘发光动画实拍融合, 15秒变形追逐视频提示词, Seedance视频prompt, H3生成视频, 视频prompt, 手绘动画接触真实物体, 蜡笔粉笔质感, 多语言视频提示词]
 ---
 
-# Handdrawn Live-Action Fusion Video Generator
+# Hand-Drawn Live-Action Fusion Video Generator
 
 Use this Prompt Guide when the user wants a **finished 15-second, 16:9 live-action-and-hand-drawn fusion video**. The output must preserve the structure: a flat hand-drawn luminous animation appears in a real space, clearly contacts live-action hands or objects in the first 0-3 seconds, continuously morphs as one single entity, escapes, and a handheld phone camera follows slightly late.
 


### PR DESCRIPTION
This PR fixes a grammar inconsistency in `prompt_guides/handdrawn_live/guide.md` (line 8).

The title uses "Handdrawn" (one word, no hyphen) while the body text consistently uses "hand-drawn" (hyphenated) on lines 2, 4, 10, 54, and 75. "Hand-drawn" is the standard English spelling. This change fixes the title to match.