### PR TITLE
Fix inconsistent capitalization in 3d_animation_short guide.md

### DIFF
--- a/prompt_guides/3d_animation_short/guide.md
+++ b/prompt_guides/3d_animation_short/guide.md
@@ -62,7 +62,7 @@ Create a story outline.
 
 Include:
 
-- Protagonist Want / Need / flaw
+- Protagonist Want / Need / Flaw
 - Core world rule
 - 8-beat causal story spine
 - Emotional anchor and payoff


### PR DESCRIPTION
This PR fixes a grammar inconsistency in `prompt_guides/3d_animation_short/guide.md` (line 65).

In the list "Protagonist Want / Need / flaw", "Want" and "Need" are capitalized but "flaw" is lowercase, breaking the parallel structure of three named story-spine components. This change capitalizes "flaw" to "Flaw" for consistency.